### PR TITLE
refactor: Use Python 3.9 type annotations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Upload Python Package to pypi
+name: Upload Python Package to PyPI
 
 on:
   release:
@@ -10,23 +10,25 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ "3.10" ]
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
 
-      - name: Install dependencies
-        run: |
-          pip install -U pip poetry
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: "1.2.0"
 
       - name: Publish package
         env:
           PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: poetry publish --build -u "__token__" -p "${{ env.PYPI_API_TOKEN }}"
+        run: |
+          poetry publish \
+            --build \
+            -u "__token__" \
+            -p "${{ env.PYPI_API_TOKEN }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: "1.2.0"
+        run: pip install -U pip poetry==1.2.0
 
       - name: Publish package
         env:
@@ -30,5 +28,5 @@ jobs:
         run: |
           poetry publish \
             --build \
-            -u "__token__" \
-            -p "${{ env.PYPI_API_TOKEN }}"
+            --username "__token__" \
+            --password "${{ env.PYPI_API_TOKEN }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   test:
@@ -26,7 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        run: pip install -U pip poetry=1.2.0
+        run: pip install -U pip poetry==1.2.0
 
       - name: Set up MongoDB
         uses: supercharge/mongodb-github-action@1.6.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,23 +15,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10" ]
+        python-version: [ "3.9", "3.10" ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: "1.2.0"
 
       - name: Set up MongoDB
         uses: supercharge/mongodb-github-action@1.6.0
 
       - name: Install dependencies
-        run: |
-          pip install -U poetry
-          poetry install -E all
+        run: poetry install -E all
 
       - name: Unit tests
         run: poetry run pytest tests --cov-report=xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,15 +26,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: "1.2.0"
+        run: pip install -U pip poetry=1.2.0
 
       - name: Set up MongoDB
         uses: supercharge/mongodb-github-action@1.6.0
 
       - name: Install dependencies
-        run: poetry install -E all
+        run: poetry install --extras all
 
       - name: Unit tests
         run: poetry run pytest tests --cov-report=xml

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Compatibilty
 
 **Required:**
-  * Python: 3.10+
+  * Python: 3.9+
   * Fastapi: 0.78+
   * Pydantic: 1.9+
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,19 +48,21 @@ and even re-use existing filters for their models.
 
 As you can see in the examples, all it takes is something along the lines of:
 
-```python hl_lines="19"
+```python hl_lines="21"
+from typing import Optional
+
 class AddressFilter(Filter):
-    street: str | None
-    country: str | None
-    city__in: list[str] | None
+    street: Optional[str]
+    country: Optional[str]
+    city__in: Optional[list[str]]
 
     class Constants(Filter.Constants):
         model = Address
 
 
 class UserFilter(Filter):
-    name: str | None
-    address: AddressFilter | None = FilterDepends(with_prefix("address", AddressFilter))
+    name: Optional[str]
+    address: Optional[AddressFilter] = FilterDepends(with_prefix("address", AddressFilter))
 
     class Constants(Filter.Constants):
         model = User
@@ -96,17 +98,19 @@ used for filtering related fields.
 The following would be equivalent:
 
 ```python
+from typing import Optional
+
 class AddressFilter(Filter):
-    street: str | None
-    country: str | None
+    street: Optional[str]
+    country: Optional[str]
 
     class Constants(Filter.Constants):
         model = Address
 
 
 class UserFilter(Filter):
-    name: str | None
-    address: AddressFilter | None = FilterDepends(with_prefix("address", AddressFilter))
+    name: Optional[str]
+    address: Optional[AddressFilter] = FilterDepends(with_prefix("address", AddressFilter))
 
     class Constants(Filter.Constants):
         model = User
@@ -116,9 +120,9 @@ AND
 
 ```python
 class UserFilter(Filter):
-    name: str | None
-    address__street: str | None
-    address__country: str | None
+    name: Optional[str]
+    address__street: Optional[str]
+    address__country: Optional[str]
 ```
 
 ## Order by
@@ -135,12 +139,12 @@ If you don't want to allow ordering on your filter, just don't add `order_by` as
 
 ### Example - Basic
 
-
 ```python
+from typing import Optional
 from fastapi_filter.contrib.sqlalchemy import Filter
 
 class UserFilter(Filter):
-    order_by: list[str] | None
+    order_by: Optional[list[str]]
 
 @app.get("/users", response_model=list[UserOut])
 async def get_users(
@@ -167,6 +171,7 @@ Valid urls:
 If for some reason you can't or don't want to use `order_by` as the field name for ordering, you can override it:
 
 ```python
+from typing import Optional
 from fastapi_filter.contrib.sqlalchemy import Filter
 
 class UserFilter(Filter):
@@ -174,7 +179,7 @@ class UserFilter(Filter):
         model = User
         ordering_field_name = "custom_order_by"
 
-    custom_order_by: list[str] | None
+    custom_order_by: Optional[list[str]]
 
 @app.get("/users", response_model=list[UserOut])
 async def get_users(
@@ -201,25 +206,26 @@ curl /users?custom_order_by=+id
 Add the following validator to your filter class:
 
 ```python
+from typing import Optional
 from fastapi_filter.contrib.sqlalchemy import Filter
 from pydantic import validator
 
 class MyFilter(Filter):
-  order_by: list[str] | None
+    order_by: Optional[list[str]]
 
-  @validator("order_by")
-  def restrict_sortable_fields(cls, value):
-      if value is None:
-          return None
+    @validator("order_by")
+    def restrict_sortable_fields(cls, value):
+        if value is None:
+            return None
 
-      allowed_field_names = ["age", "id"]
+        allowed_field_names = ["age", "id"]
 
-      for field_name in value:
-          field_name = field_name.replace("+", "").replace("-", "")  # (1)
-          if field_name not in allowed_field_names:
-              raise ValueError(f"You may only sort by: {', '.join(allowed_field_names)}")
+        for field_name in value:
+            field_name = field_name.replace("+", "").replace("-", "")  # (1)
+            if field_name not in allowed_field_names:
+                raise ValueError(f"You may only sort by: {', '.join(allowed_field_names)}")
 
-      return value
+        return value
 ```
 
 1. If you want to restrict only on specific directions, like `-created_at` and `name` for example, you can remove this

--- a/examples/fastapi_filter_mongoengine.py
+++ b/examples/fastapi_filter_mongoengine.py
@@ -1,4 +1,4 @@
-from typing import Any, Generator
+from typing import Any, Generator, Optional
 
 import uvicorn
 from bson.objectid import ObjectId
@@ -63,18 +63,18 @@ class UserOut(UserIn):
     name: str
     email: EmailStr
     age: int
-    address: AddressOut | None
+    address: Optional[AddressOut]
 
     class Config:
         orm_mode = True
 
 
 class AddressFilter(Filter):
-    street: str | None
-    country: str | None
-    city: str | None
-    city__in: list[str] | None
-    custom_order_by: list[str] | None
+    street: Optional[str]
+    country: Optional[str]
+    city: Optional[str]
+    city__in: Optional[list[str]]
+    custom_order_by: Optional[list[str]]
 
     class Constants(Filter.Constants):
         model = Address
@@ -82,9 +82,9 @@ class AddressFilter(Filter):
 
 
 class UserFilter(Filter):
-    name: str | None
-    address: AddressFilter | None = FilterDepends(with_prefix("address", AddressFilter))
-    age__lt: int | None
+    name: Optional[str]
+    address: Optional[AddressFilter] = FilterDepends(with_prefix("address", AddressFilter))
+    age__lt: Optional[int]
     age__gte: int = 10  # <-- NOTE(arthurio): This filter required
     order_by: list[str] = ["age"]
 

--- a/examples/fastapi_filter_sqlalchemy.py
+++ b/examples/fastapi_filter_sqlalchemy.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Optional
 
 import uvicorn
 from faker import Faker
@@ -58,18 +58,18 @@ class UserIn(BaseModel):
 
 class UserOut(UserIn):
     id: int
-    address: AddressOut | None
+    address: Optional[AddressOut] 
 
     class Config:
         orm_mode = True
 
 
 class AddressFilter(Filter):
-    street: str | None
-    country: str | None
-    city: str | None
-    city__in: list[str] | None
-    custom_order_by: list[str] | None
+    street: Optional[str] 
+    country: Optional[str] 
+    city: Optional[str] 
+    city__in: Optional[list[str]]
+    custom_order_by: Optional[list[str]]
 
     class Constants(Filter.Constants):
         model = Address
@@ -77,9 +77,9 @@ class AddressFilter(Filter):
 
 
 class UserFilter(Filter):
-    name: str | None
-    address: AddressFilter | None = FilterDepends(with_prefix("address", AddressFilter))
-    age__lt: int | None
+    name: Optional[str] 
+    address: Optional[AddressFilter] = FilterDepends(with_prefix("address", AddressFilter))
+    age__lt: Optional[int]
     age__gte: int = 10  # <-- NOTE(arthurio): This filter required
     order_by: list[str] = ["age"]
 

--- a/fastapi_filter/base/filter.py
+++ b/fastapi_filter/base/filter.py
@@ -130,11 +130,11 @@ def with_prefix(prefix: str, Filter: Type[BaseFilterModel]):
         from fastapi_filter.filter import FilterDepends
 
         class NumberFilter(BaseModel):
-            count: int | None
+            count: Optional[int]
 
         class MainFilter(BaseModel):
             name: str
-            number_filter: Filter | None = FilterDepends(with_prefix("number_filter", Filter))
+            number_filter: Optional[Filter] = FilterDepends(with_prefix("number_filter", Filter))
         ```
 
     As a result, you'll get the following filters:
@@ -151,11 +151,11 @@ def with_prefix(prefix: str, Filter: Type[BaseFilterModel]):
          from pydantic import BaseModel
 
         class NumberFilter(BaseModel):
-            count: int | None = Query(default=10, alias=counter)
+            count: Optional[int] = Query(default=10, alias=counter)
 
         class MainFilter(BaseModel):
             name: str
-            number_filter: Filter | None = FilterDepends(with_prefix("number_filter", Filter))
+            number_filter: Optional[Filter] = FilterDepends(with_prefix("number_filter", Filter))
         ```
 
     As a result, you'll get the following filters:

--- a/fastapi_filter/contrib/mongoengine/filter.py
+++ b/fastapi_filter/contrib/mongoengine/filter.py
@@ -16,14 +16,14 @@ class Filter(BaseFilterModel):
             created_at: DatetimeField()
 
         class MyModelFilter(Filter):
-            id: int | None
-            id__in: str | None
-            count: int | None
-            count__lte: int | None
-            created_at__gt: datetime | None
-            name__ne: str | None
-            name__nin: list[str] | None
-            name__isnull: bool | None
+            id: Optional[int]
+            id__in: Optional[str]
+            count: Optional[int]
+            count__lte: Optional[int]
+            created_at__gt: Optional[datetime]
+            name__ne: Optional[str]
+            name__nin: Optional[list[str]]
+            name__isnull: Optional[bool]
         ```
     """
 

--- a/fastapi_filter/contrib/mongoengine/filter.py
+++ b/fastapi_filter/contrib/mongoengine/filter.py
@@ -27,7 +27,7 @@ class Filter(BaseFilterModel):
         ```
     """
 
-    def sort(self, query: QuerySet):
+    def sort(self, query: QuerySet) -> QuerySet:
         if not self.ordering_values:
             return query
         return query.order_by(*self.ordering_values)
@@ -42,7 +42,7 @@ class Filter(BaseFilterModel):
             return [field.type_(v) for v in value.split(",")]
         return value
 
-    def filter(self, query: QuerySet):
+    def filter(self, query: QuerySet) -> QuerySet:
         for field_name, value in self.filtering_fields:
             field_value = getattr(self, field_name)
             if isinstance(field_value, Filter):

--- a/fastapi_filter/contrib/sqlalchemy/filter.py
+++ b/fastapi_filter/contrib/sqlalchemy/filter.py
@@ -49,12 +49,12 @@ class Filter(BaseFilterModel):
             created_at: DatetimeField()
 
         class MyModelFilter(Filter):
-            id: int | None
-            id__in: str | None
-            count: int | None
-            count__lte: int | None
-            created_at__gt: datetime | None
-            name__isnull: bool | None
+            id: Optional[int]
+            id__in: Optional[str]
+            count: Optional[int]
+            count__lte: Optional[int]
+            created_at__gt: Optional[datetime]
+            name__isnull: Optional[bool]
     """
 
     class Direction(str, Enum):

--- a/fastapi_filter/contrib/sqlalchemy/filter.py
+++ b/fastapi_filter/contrib/sqlalchemy/filter.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from enum import Enum
+from typing import Union
 
 from pydantic import validator
 from sqlalchemy.orm import Query
@@ -70,7 +71,7 @@ class Filter(BaseFilterModel):
             return [field.type_(v) for v in value.split(",")]
         return value
 
-    def filter(self, query: Query | Select):
+    def filter(self, query: Union[Query, Select]) -> Union[Query, Select]:
         for field_name, value in self.filtering_fields:
             field_value = getattr(self, field_name)
             if isinstance(field_value, Filter):
@@ -87,7 +88,7 @@ class Filter(BaseFilterModel):
 
         return query
 
-    def sort(self, query: Query | Select):
+    def sort(self, query: Union[Query, Select]) -> Union[Query, Select]:
         if not self.ordering_values:
             return query
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -111,6 +111,7 @@ mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -574,6 +575,9 @@ description = "Python implementation of Markdown."
 category = "dev"
 optional = false
 python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 
 [package.extras]
 testing = ["coverage", "pyyaml"]
@@ -1258,6 +1262,7 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 anyio = ">=3.4.0,<5"
+typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 full = ["itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests"]
@@ -1438,8 +1443,8 @@ sqlalchemy = ["SQLAlchemy"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.10"
-content-hash = "dd0ee4314e41e7ec99a4da9c6f5bd5830716f34e9998b1c03298489ecf401444"
+python-versions = "^3.9"
+content-hash = "c360313d76eae952f51eeca536c290422537cd7d5c2dc8fe5f92288270755801"
 
 [metadata.files]
 aiosqlite = [
@@ -2087,13 +2092,6 @@ pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
-    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
-    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,13 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9"
 fastapi = ">=0.78,<0.86"
 pydantic = "^1.9.0"
 mongoengine = {version = "^0.24.1", optional = true}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 import pytest
 import pytest_asyncio
@@ -23,7 +24,7 @@ def UserFilterOrderByWithDefault(User, UserFilter):
 @pytest.fixture(scope="package")
 def UserFilterOrderBy(User, UserFilter):
     class UserFilterOrderBy(UserFilter):
-        order_by: list[str] | None
+        order_by: Optional[list[str]]
 
     return UserFilterOrderBy
 
@@ -39,7 +40,7 @@ def UserFilterCustomOrderBy(UserFilter):
         class Constants(UserFilter.Constants):
             ordering_field_name = "custom_order_by"
 
-        custom_order_by: list[str] | None
+        custom_order_by: Optional[list[str]]
 
     return UserFilterCustomOrderBy
 
@@ -47,7 +48,7 @@ def UserFilterCustomOrderBy(UserFilter):
 @pytest.fixture(scope="package")
 def UserFilterRestrictedOrderBy(UserFilter):
     class UserFilterRestrictedOrderBy(UserFilter):
-        order_by: list[str] | None
+        order_by: Optional[list[str]]
 
         @validator("order_by", allow_reuse=True)
         def restrict_sortable_fields(cls, value):
@@ -70,7 +71,7 @@ def UserFilterRestrictedOrderBy(UserFilter):
 def AddressOut():
     class AddressOut(BaseModel):
         id: int
-        street: str | None
+        street: Optional[str]
         city: str
         country: str
 
@@ -86,9 +87,9 @@ def UserOut(AddressOut):
         id: int
         created_at: datetime
         updated_at: datetime
-        name: str | None
+        name: Optional[str]
         age: int
-        address: AddressOut | None
+        address: Optional[AddressOut]
 
         class Config:
             orm_mode = True

--- a/tests/test_mongoengine/conftest.py
+++ b/tests/test_mongoengine/conftest.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Generator
+from typing import Any, Generator, Optional
 
 import pytest
 from bson.objectid import ObjectId
@@ -105,11 +105,11 @@ def users(User, Address):
 @pytest.fixture(scope="package")
 def AddressFilter(Address, Filter):
     class AddressFilter(Filter):
-        street__isnull: bool | None
-        country: str | None
-        city: str | None
-        city__in: list[str] | None
-        country__nin: list[str] | None
+        street__isnull: Optional[bool]
+        country: Optional[str]
+        city: Optional[str]
+        city__in: Optional[list[str]]
+        country__nin: Optional[list[str]]
 
         class Constants(Filter.Constants):
             model = Address
@@ -120,18 +120,18 @@ def AddressFilter(Address, Filter):
 @pytest.fixture(scope="package")
 def UserFilter(User, Filter, AddressFilter):
     class UserFilter(Filter):
-        name: str | None
-        name__in: list[str] | None
-        name__nin: list[str] | None
-        name__ne: str | None
-        name__isnull: bool | None
-        age: int | None
-        age__lt: int | None
-        age__lte: int | None
-        age__gt: int | None
-        age__gte: int | None
-        age__in: list[int] | None
-        address: AddressFilter | None = FilterDepends(with_prefix("address", AddressFilter))
+        name: Optional[str]
+        name__in: Optional[list[str]]
+        name__nin: Optional[list[str]]
+        name__ne: Optional[str]
+        name__isnull: Optional[bool]
+        age: Optional[int]
+        age__lt: Optional[int]
+        age__lte: Optional[int]
+        age__gt: Optional[int]
+        age__gte: Optional[int]
+        age__in: Optional[list[int]]
+        address: Optional[AddressFilter] = FilterDepends(with_prefix("address", AddressFilter))
 
         class Constants(Filter.Constants):
             model = User
@@ -143,7 +143,7 @@ def UserFilter(User, Filter, AddressFilter):
 def AddressOut(PydanticObjectId):
     class AddressOut(BaseModel):
         id: PydanticObjectId = Field(..., alias="_id")
-        street: str | None
+        street: Optional[str]
         city: str
         country: str
 
@@ -158,7 +158,7 @@ def UserOut(PydanticObjectId, AddressOut):
     class UserOut(BaseModel):
         id: PydanticObjectId = Field(..., alias="_id")
         created_at: datetime
-        name: str | None
+        name: Optional[str]
         age: int
         address: AddressOut | None
 

--- a/tests/test_mongoengine/conftest.py
+++ b/tests/test_mongoengine/conftest.py
@@ -160,7 +160,7 @@ def UserOut(PydanticObjectId, AddressOut):
         created_at: datetime
         name: Optional[str]
         age: int
-        address: AddressOut | None
+        address: Optional[AddressOut]
 
         class Config:
             orm_mode = True

--- a/tests/test_sqlalchemy/conftest.py
+++ b/tests/test_sqlalchemy/conftest.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional
 
 import pytest
 import pytest_asyncio
@@ -133,10 +133,10 @@ def Filter():
 @pytest.fixture(scope="package")
 def AddressFilter(Address, Filter):
     class AddressFilter(Filter):
-        street__isnull: bool | None
-        city: str | None
-        city__in: list[str] | None
-        country__not_in: list[str] | None
+        street__isnull: Optional[bool]
+        city: Optional[str]
+        city__in: Optional[list[str]]
+        country__not_in: Optional[list[str]]
 
         class Constants(Filter.Constants):
             model = Address
@@ -147,19 +147,19 @@ def AddressFilter(Address, Filter):
 @pytest.fixture(scope="package")
 def UserFilter(User, Filter, AddressFilter):
     class UserFilter(Filter):
-        name: str | None
-        name__in: list[str] | None
-        name__not: str | None
-        name__not_in: list[str] | None
-        name__isnull: bool | None
-        age: int | None
-        age__lt: int | None
-        age__lte: int | None
-        age__gt: int | None
-        age__gte: int | None
-        age__in: list[int] | None
-        address: AddressFilter | None = FilterDepends(with_prefix("address", AddressFilter))
-        address_id__isnull: bool | None
+        name: Optional[str]
+        name__in: Optional[list[str]]
+        name__not: Optional[str]
+        name__not_in: Optional[list[str]]
+        name__isnull: Optional[bool]
+        age: Optional[int]
+        age__lt: Optional[int]
+        age__lte: Optional[int]
+        age__gt: Optional[int]
+        age__gte: Optional[int]
+        age__in: Optional[list[int]]
+        address: Optional[AddressFilter]= FilterDepends(with_prefix("address", AddressFilter))
+        address_id__isnull: Optional[bool]
 
         class Constants(Filter.Constants):
             model = User


### PR DESCRIPTION
## what.

* Refactor codebase to use old-style type annotations like `Union` and `Optional` in place of Python 3.10's new `|` (union) operator.
* Update workflows to run tests against Python 3.9, simplify publishing pipeline
* Update workflows to install Poetry via github action
* Update README and other docs mentioning minimum supported version.

## why.

To support still alive Python 3.9 version.
There might be more work needed in order to support earlier versions, I just need this to work under 3.9.
IMHO rewriting this to support Py3.7 is not worth it, as it's going EOL in 9 months. Maybe 3.8 is worth supporting.

## references.

Fixes #109

https://endoflife.date/python
