### PR TITLE
added contains express support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ fastapi_filter.sqlite
 poetry.toml
 .pytest_cache/
 .ruff_cache/
+__pycache__

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ By default, **fastapi_filter** supports the following operators:
   - `not`/`ne`
   - `not_in`/`nin`
   - `like`/`ilike`
+  - `contains`
 
 _**Note:** Mysql excludes `None` values when using `in` filter_
 

--- a/examples/fastapi_filter_sqlalchemy.py
+++ b/examples/fastapi_filter_sqlalchemy.py
@@ -95,6 +95,7 @@ class UserFilter(Filter):
     name: Optional[str]
     name__ilike: Optional[str]
     name__like: Optional[str]
+    name__contains: Optional[str]
     name__neq: Optional[str]
     address: Optional[AddressFilter] = FilterDepends(with_prefix("address", AddressFilter))
     age__lt: Optional[int]

--- a/fastapi_filter/contrib/sqlalchemy/filter.py
+++ b/fastapi_filter/contrib/sqlalchemy/filter.py
@@ -44,6 +44,7 @@ _orm_operator_transformer = {
     # XXX(arthurio): Mysql excludes None values when using `in` or `not in` filters.
     "not": lambda value: ("is_not", value),
     "not_in": lambda value: ("not_in", value),
+    "contains": lambda value: ("contains", value),
 }
 """Operators à la Django.
 

--- a/tests/test_sqlalchemy/conftest.py
+++ b/tests/test_sqlalchemy/conftest.py
@@ -265,6 +265,7 @@ def UserFilter(User, Filter, AddressFilter):
         name: Optional[str]
         name__neq: Optional[str]
         name__like: Optional[str]
+        name__contains: Optional[str]
         name__ilike: Optional[str]
         name__in: Optional[List[str]]
         name__not: Optional[str]

--- a/tests/test_sqlalchemy/test_filter.py
+++ b/tests/test_sqlalchemy/test_filter.py
@@ -9,6 +9,8 @@ from sqlalchemy.future import select
     "filter_,expected_count",
     [
         [{"name": "Mr Praline"}, 1],
+        [{"name__contains": "Mr"}, 2],
+        [{"name__contains": "mR"}, 2],
         [{"name__neq": "Mr Praline"}, 4],
         [{"name__in": "Mr Praline,Mr Creosote,Gumbys,Knight"}, 3],
         [{"name__like": "%Mr%"}, 2],
@@ -60,6 +62,8 @@ async def test_filter_deprecation_like_and_ilike(session, Address, User, UserFil
     "filter_,expected_count",
     [
         [{"name": "Mr Praline"}, 1],
+        [{"name__contains": "Mr"}, 2],
+        [{"name__contains": "mR"}, 2],
         [{"name__in": "Mr Praline,Mr Creosote,Gumbys,Knight"}, 3],
         [{"name__isnull": True}, 1],
         [{"name__isnull": False}, 5],
@@ -89,7 +93,8 @@ async def test_api(test_client, users, filter_, expected_count):
         [{"is_individual": False}, status.HTTP_200_OK],
         [{}, status.HTTP_422_UNPROCESSABLE_ENTITY],
         [{"is_individual": None}, status.HTTP_422_UNPROCESSABLE_ENTITY],
-        [{"is_individual": True, "bogus_filter": "bad"}, status.HTTP_422_UNPROCESSABLE_ENTITY],
+        [{"is_individual": True, "bogus_filter": "bad"},
+            status.HTTP_422_UNPROCESSABLE_ENTITY],
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why this PR?

Recently I started using https://sqlalchemy-utils.readthedocs.io/en/latest/_modules/sqlalchemy_utils/types/scalar_list.html to store array of enum.

for which I need to filter table with specific value inside array of enum (TEXT/BLOB at low level) which is feasible using `contains` expression.

## What is changed/added ?

- Added `contains` expression support for `sqlalchemy` and testcases to support it.
- Updated Doc/Example