### PR TITLE
Add between as a usable operator

### DIFF
--- a/examples/fastapi_filter_sqlalchemy.py
+++ b/examples/fastapi_filter_sqlalchemy.py
@@ -101,6 +101,8 @@ class UserFilter(Filter):
 
     See: https://github.com/tiangolo/fastapi/issues/4700 for why we need to wrap `Query` in `Field`.
     """
+    age__in: Optional[List[int]] = None
+    age__between: Optional[List[List[int]]] = None
     order_by: List[str] = ["age"]
     search: Optional[str] = None
 

--- a/tests/test_sqlalchemy/conftest.py
+++ b/tests/test_sqlalchemy/conftest.py
@@ -274,6 +274,7 @@ def UserFilter(User, Filter, AddressFilter):
         age__gt: Optional[int] = None
         age__gte: Optional[int] = None
         age__in: Optional[List[int]] = None
+        age__between: Optional[List[int]] = None
         address: Optional[AddressFilter] = FilterDepends(  # type: ignore[valid-type]
             with_prefix("address", AddressFilter), by_alias=True
         )

--- a/tests/test_sqlalchemy/test_filter.py
+++ b/tests/test_sqlalchemy/test_filter.py
@@ -27,6 +27,8 @@ from sqlalchemy.future import select
         [{"address": {"country__not_in": ["France"]}}, 3],
         [{"age__in": "1"}, 1],
         [{"age__in": "21,33"}, 3],
+        [{"age__between": [21,33]}, 3],
+        [{"age__between": "21,33"}, 3],
         [{"address": {"country__not_in": "France"}}, 3],
         [{"address": {"street__isnull": True}}, 2],
         [{"address": {"city__in": ["Nantes", "Denver"]}}, 3],


### PR DESCRIPTION
This PR aims to expose the [between()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.between) operator present in SQLAlchemy.

While the conjunction of `lte` and `gte` operators can suffice when dealing with numerical columns this opens the possibility of using the operator also on textual and date columns with a single operator. 

The proposed implementation asks the user to input a list, the first two element are considered the right and left sides of the queried interval. If more than two elements are present they are simply ignored.