### PR TITLE
Replace deprecated status.HTTP_422_UNPROCESSABLE_ENTITY with status.HTTP_422_UNPROCESSABLE_CONTENT

### DIFF
--- a/tests/test_beanie/test_filter.py
+++ b/tests/test_beanie/test_filter.py
@@ -3,6 +3,10 @@ from urllib.parse import urlencode
 import pytest
 from fastapi import status
 
+# for compatibility with starlette < 0.47.0; HTTP_422_UNPROCESSABLE_ENTITY is deprecated in the later versions
+if not hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
+    status.HTTP_422_UNPROCESSABLE_CONTENT = status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 @pytest.mark.parametrize(
     "filter_,expected_count",
@@ -63,9 +67,9 @@ async def test_api(test_client, uri, filter_, expected_count):
     (
         ({"is_individual": True}, status.HTTP_200_OK),
         ({"is_individual": False}, status.HTTP_200_OK),
-        ({}, status.HTTP_422_UNPROCESSABLE_ENTITY),
-        ({"is_individual": None}, status.HTTP_422_UNPROCESSABLE_ENTITY),
-        [{"is_individual": True, "bogus_filter": "bad"}, status.HTTP_422_UNPROCESSABLE_ENTITY],
+        ({}, status.HTTP_422_UNPROCESSABLE_CONTENT),
+        ({"is_individual": None}, status.HTTP_422_UNPROCESSABLE_CONTENT),
+        [{"is_individual": True, "bogus_filter": "bad"}, status.HTTP_422_UNPROCESSABLE_CONTENT],
     ),
 )
 @pytest.mark.asyncio

--- a/tests/test_beanie/test_order_by.py
+++ b/tests/test_beanie/test_order_by.py
@@ -2,6 +2,10 @@ import pytest
 from fastapi import status
 from pydantic import ValidationError
 
+# for compatibility with starlette < 0.47.0; HTTP_422_UNPROCESSABLE_ENTITY is deprecated in the later versions
+if not hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
+    status.HTTP_422_UNPROCESSABLE_CONTENT = status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 @pytest.mark.parametrize(
     "order_by,assert_function",
@@ -172,7 +176,7 @@ async def test_api_order_by(test_client, order_by, assert_function):
 async def test_api_order_by_invalid_field(test_client):
     endpoint = "/users_with_order_by?order_by=invalid"
     response = await test_client.get(endpoint)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 @pytest.mark.asyncio
@@ -189,8 +193,8 @@ async def test_api_no_order_by(test_client):
     [
         [None, lambda previous_user, user: True, status.HTTP_200_OK],
         ["", lambda previous_user, user: True, status.HTTP_200_OK],
-        ["name", None, status.HTTP_422_UNPROCESSABLE_ENTITY],
-        ["age,-name", None, status.HTTP_422_UNPROCESSABLE_ENTITY],
+        ["name", None, status.HTTP_422_UNPROCESSABLE_CONTENT],
+        ["age,-name", None, status.HTTP_422_UNPROCESSABLE_CONTENT],
         ["-age", lambda previous_user, user: previous_user["age"] >= user["age"], status.HTTP_200_OK],
         [
             "age,-created_at",

--- a/tests/test_mongoengine/test_filter.py
+++ b/tests/test_mongoengine/test_filter.py
@@ -3,6 +3,10 @@ from urllib.parse import urlencode
 import pytest
 from fastapi import status
 
+# for compatibility with starlette < 0.47.0; HTTP_422_UNPROCESSABLE_ENTITY is deprecated in the later versions
+if not hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
+    status.HTTP_422_UNPROCESSABLE_CONTENT = status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 @pytest.mark.parametrize(
     "filter_,expected_count",
@@ -62,9 +66,9 @@ async def test_api(test_client, uri, filter_, expected_count):
     (
         ({"is_individual": True}, status.HTTP_200_OK),
         ({"is_individual": False}, status.HTTP_200_OK),
-        ({}, status.HTTP_422_UNPROCESSABLE_ENTITY),
-        ({"is_individual": None}, status.HTTP_422_UNPROCESSABLE_ENTITY),
-        [{"is_individual": True, "bogus_filter": "bad"}, status.HTTP_422_UNPROCESSABLE_ENTITY],
+        ({}, status.HTTP_422_UNPROCESSABLE_CONTENT),
+        ({"is_individual": None}, status.HTTP_422_UNPROCESSABLE_CONTENT),
+        [{"is_individual": True, "bogus_filter": "bad"}, status.HTTP_422_UNPROCESSABLE_CONTENT],
     ),
 )
 @pytest.mark.asyncio

--- a/tests/test_mongoengine/test_order_by.py
+++ b/tests/test_mongoengine/test_order_by.py
@@ -2,6 +2,10 @@ import pytest
 from fastapi import status
 from pydantic import ValidationError
 
+# for compatibility with starlette < 0.47.0; HTTP_422_UNPROCESSABLE_ENTITY is deprecated in the later versions
+if not hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
+    status.HTTP_422_UNPROCESSABLE_CONTENT = status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 @pytest.mark.parametrize(
     "order_by,assert_function",
@@ -166,7 +170,7 @@ async def test_api_order_by(test_client, order_by, assert_function):
 async def test_api_order_by_invalid_field(test_client):
     endpoint = "/users_with_order_by?order_by=invalid"
     response = await test_client.get(endpoint)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 @pytest.mark.asyncio
@@ -183,8 +187,8 @@ async def test_api_no_order_by(test_client):
     [
         [None, lambda previous_user, user: True, status.HTTP_200_OK],
         ["", lambda previous_user, user: True, status.HTTP_200_OK],
-        ["name", None, status.HTTP_422_UNPROCESSABLE_ENTITY],
-        ["age,-name", None, status.HTTP_422_UNPROCESSABLE_ENTITY],
+        ["name", None, status.HTTP_422_UNPROCESSABLE_CONTENT],
+        ["age,-name", None, status.HTTP_422_UNPROCESSABLE_CONTENT],
         ["-age", lambda previous_user, user: previous_user["age"] >= user["age"], status.HTTP_200_OK],
         [
             "age,-created_at",

--- a/tests/test_sqlalchemy/test_filter.py
+++ b/tests/test_sqlalchemy/test_filter.py
@@ -4,6 +4,10 @@ import pytest
 from fastapi import status
 from sqlalchemy.future import select
 
+# for compatibility with starlette < 0.47.0; HTTP_422_UNPROCESSABLE_ENTITY is deprecated in the later versions
+if not hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
+    status.HTTP_422_UNPROCESSABLE_CONTENT = status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 @pytest.mark.parametrize(
     "filter_,expected_count",
@@ -96,9 +100,9 @@ async def test_api(test_client, uri, filter_, expected_count):
     [
         [{"is_individual": True}, status.HTTP_200_OK],
         [{"is_individual": False}, status.HTTP_200_OK],
-        [{}, status.HTTP_422_UNPROCESSABLE_ENTITY],
-        [{"is_individual": None}, status.HTTP_422_UNPROCESSABLE_ENTITY],
-        [{"is_individual": True, "bogus_filter": "bad"}, status.HTTP_422_UNPROCESSABLE_ENTITY],
+        [{}, status.HTTP_422_UNPROCESSABLE_CONTENT],
+        [{"is_individual": None}, status.HTTP_422_UNPROCESSABLE_CONTENT],
+        [{"is_individual": True, "bogus_filter": "bad"}, status.HTTP_422_UNPROCESSABLE_CONTENT],
     ],
 )
 @pytest.mark.usefixtures("sports")

--- a/tests/test_sqlalchemy/test_order_by.py
+++ b/tests/test_sqlalchemy/test_order_by.py
@@ -3,6 +3,10 @@ from fastapi import status
 from pydantic import ValidationError
 from sqlalchemy import select
 
+# for compatibility with starlette < 0.47.0; HTTP_422_UNPROCESSABLE_ENTITY is deprecated in the later versions
+if not hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
+    status.HTTP_422_UNPROCESSABLE_CONTENT = status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 @pytest.mark.parametrize(
     "order_by,assert_function",
@@ -207,7 +211,7 @@ async def test_api_order_by(test_client, users, order_by, assert_function):
 async def test_api_order_by_invalid_field(test_client, session):
     endpoint = "/users_with_order_by?order_by=invalid"
     response = await test_client.get(endpoint)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 @pytest.mark.asyncio
@@ -224,8 +228,8 @@ async def test_api_no_order_by(test_client, session):
     [
         [None, lambda previous_user, user: True, status.HTTP_200_OK],
         ["", lambda previous_user, user: True, status.HTTP_200_OK],
-        ["name", None, status.HTTP_422_UNPROCESSABLE_ENTITY],
-        ["age,-name", None, status.HTTP_422_UNPROCESSABLE_ENTITY],
+        ["name", None, status.HTTP_422_UNPROCESSABLE_CONTENT],
+        ["age,-name", None, status.HTTP_422_UNPROCESSABLE_CONTENT],
         ["-age", lambda previous_user, user: previous_user["age"] >= user["age"], status.HTTP_200_OK],
         [
             "age,-created_at",


### PR DESCRIPTION
Fixes failing tests.
Related to https://github.com/Kludex/starlette/pull/2939